### PR TITLE
[Deploy] Stabilize PNPM Install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS base
+FROM node:22 AS base
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:lts AS base
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 
-# By copying only the package.json and pnpm-lock.yaml here, the deps steps are
-# cached unless dependencies change.
-COPY package.json pnpm-lock.yaml ./
+# By copying only the package manager manifests here, the deps steps are cached
+# unless dependencies or install policy change.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 FROM base AS build-deps
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "apw",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Summary:
- Pin the Docker build to pnpm 11.1.2 instead of pnpm@latest.
- Pin the Docker Node base image to node:22 instead of the moving node:lts tag.
- Add pnpm v11 allowBuilds entries for esbuild and sharp.
- Copy pnpm-workspace.yaml into the Docker dependency layer before pnpm install.

Validation:
- pnpm install --frozen-lockfile
- pnpm install --lockfile-only (no pnpm-lock.yaml diff under pnpm 11.1.2)
- clean manifest-only pnpm install --frozen-lockfile
- pnpm run build
- docker build --pull=false --progress=plain -t apw-deploy-check .

Docker note:
- Direct Docker Hub pulls from the local daemon hung before output, so I pulled official base images through mirror.gcr.io and tagged them locally before building with --pull=false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned pnpm package manager version to 11.1.2 across Docker configuration and package settings to ensure consistent builds across environments.
  * Updated build configuration to enable support for additional native module builders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rasulkireev/apw/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->