### PR TITLE
Add personal MCP section to about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -59,6 +59,21 @@ const pageType = "profile";
         a plant alive for more than a week.
       </p>
 
+      <section class="pt-6 mt-8 border-t border-gray-200">
+        <h2 class="mt-0 mb-3 text-2xl font-bold">Learn more about me with MCP</h2>
+        <p>
+          I run a small public Model Context Protocol (MCP) server at
+          <Link href="https://mcp.rasulkireev.com">mcp.rasulkireev.com</Link>. If you are using an AI assistant
+          or hiring workflow that supports remote MCP servers, you can connect it to learn more about my public work,
+          strengths, work style, and current focus.
+        </p>
+        <p>
+          Use <code>https://mcp.rasulkireev.com/mcp</code> as the MCP endpoint. The server currently exposes the
+          <code>get_profile</code> tool, the <code>profile://rasul</code> resource, and an <code>evaluate_fit</code>
+          prompt for comparing my public profile against a role or opportunity.
+        </p>
+      </section>
+
       <SocialLinks />
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add a bottom section on the About page explaining Rasul's personal MCP server
- include the remote MCP endpoint and available tool/resource/prompt

## Test
- COREPACK_HOME=/home/node/.cache/corepack pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new section to the About page called "Learn more about me with MCP" that provides details about a public Model Context Protocol (MCP) server. This section includes the server URL, endpoint information, and describes the tools, resources, and prompts available through the server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rasulkireev/apw/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->