### PR TITLE
[Content] Add Automation Link Attribution

### DIFF
--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -1,4 +1,17 @@
 ---
+type AttributionParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+interface Props {
+  href?: string | URL;
+  class?: string;
+  attribution?: string | AttributionParams;
+  rel?: string;
+  target?: string;
+}
+
 const {
   href,
   class: className,
@@ -12,21 +25,21 @@ let hrefValue = href ? href.toString() : "";
 let isExternal = false;
 let externalDomain = "";
 
-const getAttributionParams = () => {
+const getAttributionParams = (source: string): AttributionParams | null => {
   if (!attribution) {
     return null;
   }
 
   if (typeof attribution === "string") {
     return {
-      ref: "rasulkireev.com",
-      utm_source: "rasulkireev.com",
+      ref: source,
+      utm_source: source,
       utm_medium: "referral",
       utm_campaign: attribution,
     };
   }
 
-  if (typeof attribution === "object") {
+  if (typeof attribution === "object" && !Array.isArray(attribution)) {
     return attribution;
   }
 
@@ -42,11 +55,11 @@ if (hrefValue) {
     externalDomain = url.hostname;
 
     if (isExternal) {
-      const attributionParams = getAttributionParams();
+      const attributionParams = getAttributionParams(siteHost);
 
       if (attributionParams) {
         Object.entries(attributionParams).forEach(([key, value]) => {
-          if (value) {
+          if (value !== null && value !== undefined && value !== "") {
             url.searchParams.set(key, value.toString());
           }
         });

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -2,14 +2,36 @@
 const {
   href,
   class: className,
+  attribution,
   rel: relProp,
   target: targetProp,
   ...rest
 } = Astro.props;
 
-const hrefValue = href ? href.toString() : "";
+let hrefValue = href ? href.toString() : "";
 let isExternal = false;
 let externalDomain = "";
+
+const getAttributionParams = () => {
+  if (!attribution) {
+    return null;
+  }
+
+  if (typeof attribution === "string") {
+    return {
+      ref: "rasulkireev.com",
+      utm_source: "rasulkireev.com",
+      utm_medium: "referral",
+      utm_campaign: attribution,
+    };
+  }
+
+  if (typeof attribution === "object") {
+    return attribution;
+  }
+
+  return null;
+};
 
 if (hrefValue) {
   try {
@@ -18,6 +40,19 @@ if (hrefValue) {
     const isHttp = url.protocol === "http:" || url.protocol === "https:";
     isExternal = isHttp && url.hostname && url.hostname !== siteHost;
     externalDomain = url.hostname;
+
+    if (isExternal) {
+      const attributionParams = getAttributionParams();
+
+      if (attributionParams) {
+        Object.entries(attributionParams).forEach(([key, value]) => {
+          if (value) {
+            url.searchParams.set(key, value.toString());
+          }
+        });
+        hrefValue = url.toString();
+      }
+    }
   } catch {
     // Ignore invalid URLs; treat as internal.
   }

--- a/src/content/articles/in-search-of-great-automations.mdx
+++ b/src/content/articles/in-search-of-great-automations.mdx
@@ -19,17 +19,17 @@ I've been thinking a lot about automations lately.
 
 Not in the abstract "AI will do everything for us" kind of way. More in the very practical, slightly boring way. What annoying things do I do every week? What information do I keep looking up? What decisions could be easier if the right context was already there?
 
-This is one of the reasons I am excited about <Link href="https://github.com/openclaw/openclaw">OpenClaw</Link>, <Link href="https://openai.com/academy/codex-automations/">Codex Automations</Link>, and tools like them. I also wrote a short [OpenClaw deployment guide](/openclaw-with-docker-practical-setup-guide/) because it feels like we are getting closer to the point where I can have agents help with more of the background work of life and projects.
+This is one of the reasons I am excited about <Link href="https://github.com/openclaw/openclaw" attribution="in_search_of_great_automations">OpenClaw</Link>, <Link href="https://openai.com/academy/codex-automations/" attribution="in_search_of_great_automations">Codex Automations</Link>, and tools like them. I also wrote a short [OpenClaw deployment guide](/openclaw-with-docker-practical-setup-guide/) because it feels like we are getting closer to the point where I can have agents help with more of the background work of life and projects.
 
 But there is one problem.
 
 Agents are only useful when they have the right data.
 
-Sherlock Holmes put it well in *A Scandal in Bohemia*: <Link href="https://www.gutenberg.org/files/48320/48320-h/48320-h.htm">"It is a capital mistake to theorize before one has data."</Link>
+Sherlock Holmes put it well in *A Scandal in Bohemia*: <Link href="https://www.gutenberg.org/files/48320/48320-h/48320-h.htm" attribution="in_search_of_great_automations">"It is a capital mistake to theorize before one has data."</Link>
 
 This sounds obvious, but I think it is the main thing. If an agent doesn't know [what is happening in my life](/february-2025/#documentation-and-reflection), it can't really help. It can write a nice generic answer, but it can't notice the thing I forgot, connect two events together, or remind me about something that is quietly becoming a problem.
 
-That is why I liked playing around with <Link href="https://www.openbudget.sh/">OpenBudget</Link>. The idea is simple: give AI tools access to your finance data, and then ask questions about it in normal language.
+That is why I liked playing around with <Link href="https://www.openbudget.sh/" attribution="in_search_of_great_automations">OpenBudget</Link>. The idea is simple: give AI tools access to your finance data, and then ask questions about it in normal language.
 
 Personal finances are a perfect example of data that already exists, but is usually painful to use. I don't want to spend a Sunday exporting CSVs and looking through bank statements. I want to ask:
 


### PR DESCRIPTION
## Summary
- Add opt-in outbound attribution support to the shared Link component
- Tag external links in the automation article with source/referral UTM parameters

## Testing
- pnpm build
- Verified generated automation article HTML includes ref and UTM params on external links